### PR TITLE
Closing unclosed file

### DIFF
--- a/Randomizer/Randomizer.py
+++ b/Randomizer/Randomizer.py
@@ -44,7 +44,7 @@ class Randomizer:
         self.__apply_ips_patches__(ips_patches_list)
         self.__apply_patches__(patch_list)
         self.__apply_generators__(generator_list)
-
+        self.file.close()
         # Assume headerless and add header
         __add_header__(headers[0], output_file)
 


### PR DESCRIPTION
Currently we don't close our output file. This was causing issues of the last write not being saved to disk before adding our header. As part of exiting the program it would close the file automatically - applying our last write after adding the header, which cause the data to be off by 0x10 (the size of the header)

Let me know if we want to refactor this into closing the file another way.